### PR TITLE
fix: upgrade Woodpecker from v2 to v3.13.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   # Documentation: https://woodpecker-ci.org/docs/administration/server-config
   # ---------------------------------------------------------------------------
   woodpecker-server:
-    image: woodpeckerci/woodpecker-server:latest
+    image: woodpeckerci/woodpecker-server:v3
     container_name: woodpecker-server
     restart: unless-stopped
     
@@ -38,9 +38,7 @@ services:
     
     volumes:
       # Persistent data (database, etc.)
-      - ${WOODPECKER_DATA_DIR:-./data/woodpecker}:/data
-      # Logs directory
-      - ${WOODPECKER_LOGS_DIR:-./data/logs}:/logs
+      - ${WOODPECKER_DATA_DIR:-./data/woodpecker}:/var/lib/woodpecker
     
     environment:
       # Server configuration
@@ -56,7 +54,7 @@ services:
       
       # Database configuration
       - WOODPECKER_DATABASE_DRIVER=${WOODPECKER_DATABASE_DRIVER:-sqlite3}
-      - WOODPECKER_DATABASE_DATASOURCE=${WOODPECKER_DATABASE_DATASOURCE:-/data/woodpecker.sqlite}
+      - WOODPECKER_DATABASE_DATASOURCE=${WOODPECKER_DATABASE_DATASOURCE:-/var/lib/woodpecker/woodpecker.sqlite}
       
       # GitHub OAuth configuration
       - WOODPECKER_GITHUB=${WOODPECKER_GITHUB:-true}
@@ -71,7 +69,6 @@ services:
       
       # Logging
       - WOODPECKER_LOG_LEVEL=${LOG_LEVEL:-info}
-      - WOODPECKER_LOG_FILE=/logs/woodpecker-server.log
     
     networks:
       - traefik
@@ -94,7 +91,7 @@ services:
     
     labels:
       - "com.woodpecker.component=server"
-      - "com.woodpecker.version=latest"
+      - "com.woodpecker.version=v3"
       # Traefik reverse proxy
       - "traefik.enable=true"
       - "traefik.http.routers.woodpecker.rule=Host(`ci.sparkfn.io`)"
@@ -109,8 +106,9 @@ services:
   # Documentation: https://woodpecker-ci.org/docs/administration/agent-config
   # ---------------------------------------------------------------------------
   woodpecker-agent:
-    image: woodpeckerci/woodpecker-agent:latest
+    image: woodpeckerci/woodpecker-agent:v3
     container_name: woodpecker-agent
+    command: agent
     restart: unless-stopped
     
     # Run after server is healthy
@@ -122,8 +120,6 @@ services:
       # Docker socket for running containerized steps
       # WARNING: This gives the agent container access to host Docker daemon
       - /var/run/docker.sock:/var/run/docker.sock
-      # Logs directory
-      - ${WOODPECKER_LOGS_DIR:-./data/logs}:/logs
     
     environment:
       # Server connection
@@ -164,7 +160,7 @@ services:
     
     labels:
       - "com.woodpecker.component=agent"
-      - "com.woodpecker.version=latest"
+      - "com.woodpecker.version=v3"
 
 # =============================================================================
 # Networks


### PR DESCRIPTION
## Summary

- Pin images to `woodpeckerci/*:v3` (v2 `latest` tag was pulling buggy v2.8.3)
- Update data mount path from `/data` to `/var/lib/woodpecker` (v3 default)
- Add `command: agent` to agent service (required in v3)
- Remove log file volume (v3 logs to stdout)

## Test plan

- [x] Server starts cleanly: `Woodpecker server with version '3.13.0'`
- [x] `curl http://localhost:8090/healthz` returns 204
- [x] Both containers healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)