### PR TITLE
fix: pin Woodpecker v3.13.0, v3 compat, Docker address pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10] - 2026-02-07
+
+### Fixed
+- Pin Woodpecker images to `v3.13.0` (rolling `v3` tag caused server/agent version mismatch)
+- Upgrade from Woodpecker v2 to v3 (v2 `latest` tag pulled buggy v2.8.3)
+- Use `woodpecker-server ping` for healthcheck (distroless image has no wget/curl)
+- Use external `traefik` network only (avoid Docker subnet pool exhaustion)
+- Update data mount path to `/var/lib/woodpecker` (v3 default)
+- Add `command: agent` to agent service (required in v3)
+- Configure Docker daemon address pools (`/24` subnets) to support pipeline network creation
+
+### Validated
+- End-to-end pipeline execution with `whatsappWebJs_frontend` trial
+- GitHub webhook → Woodpecker → clone → install → lint → test → build flow confirmed working
+
 ## [0.0.9] - 2026-02-07
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   # Documentation: https://woodpecker-ci.org/docs/administration/server-config
   # ---------------------------------------------------------------------------
   woodpecker-server:
-    image: woodpeckerci/woodpecker-server:v3
+    image: woodpeckerci/woodpecker-server:v3.13.0
     container_name: woodpecker-server
     restart: unless-stopped
     
@@ -106,7 +106,7 @@ services:
   # Documentation: https://woodpecker-ci.org/docs/administration/agent-config
   # ---------------------------------------------------------------------------
   woodpecker-agent:
-    image: woodpeckerci/woodpecker-agent:v3
+    image: woodpeckerci/woodpecker-agent:v3.13.0
     container_name: woodpecker-agent
     command: agent
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Pin images to `v3.13.0` (rolling `v3` tag caused server/agent version mismatch)
- Full v3 compatibility: data path, agent command, log output
- Use `traefik` external network only (no separate woodpecker-network)
- Docker daemon `/24` subnets to support pipeline network creation
- Updated CHANGELOG with v0.0.10

## Validated

- End-to-end: GitHub push → webhook → Woodpecker → clone → install → lint → test → build
- whatsappWebJs_frontend pipeline passed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)