### PR TITLE
Fix agent healthcheck + update changelog to v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11] - 2026-02-07
+
+### Fixed
+- Agent healthcheck: use `/bin/woodpecker-agent ping` instead of `pgrep` (distroless image)
+
+### Validated
+- End-to-end pipeline for `whatsappWebJs_api` trial (install → wait-for-db → test → build)
+- Pipeline failure notification: auto-creates GitHub issue on both API and frontend repos
+- `notify-failure` step correctly skips on success, triggers on failure
+
 ## [0.0.10] - 2026-02-07
 
 ### Fixed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # Woodpecker CI/CD - Docker Compose Configuration
 # =============================================================================
-# Version: 0.0.9
+# Version: 0.0.11
 #
 # This file defines the Woodpecker CI server and agent containers.
 #
@@ -144,7 +144,7 @@ services:
     
     # Health check - verify agent can connect to server
     healthcheck:
-      test: ["CMD", "pgrep", "-f", "woodpecker-agent"]
+      test: ["CMD", "/bin/woodpecker-agent", "ping"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- Fix agent healthcheck: replace `pgrep` with `/bin/woodpecker-agent ping` (distroless image)
- Update CHANGELOG for v0.0.11 with API pipeline trial and failure notification docs

Closes #6

## Test plan
- [x] Agent reports healthy with new healthcheck command
- [x] Both whatsappWebJs repos have working pipelines with failure notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)