### PR TITLE
feat: add webhook handler Docker service with Traefik routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ WOODPECKER_GITHUB_SECRET=your-github-oauth-client-secret
 # GitHub API token for issue/PR creation
 GITHUB_TOKEN=ghp_your-personal-access-token
 
+# Woodpecker API token (generate via Woodpecker UI → User Settings → API)
+WOODPECKER_TOKEN=your-woodpecker-api-token
+
 # -----------------------------------------------------------------------------
 # Database
 # -----------------------------------------------------------------------------
@@ -81,8 +84,10 @@ DEPLOY_DOCKER_HOST=unix:///var/run/docker.sock
 # Notification & Webhook
 # -----------------------------------------------------------------------------
 # Webhook endpoint for external notifications
-WEBHOOK_ENDPOINT=http://localhost:8080/webhook
+WEBHOOK_ENDPOINT=https://ci.sparkfn.io/webhooks
 WEBHOOK_SECRET=your-webhook-secret
+WEBHOOK_PORT=9000
+WEBHOOK_VERBOSE=false
 
 # Polling interval (seconds)
 POLL_INTERVAL=60

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,15 @@
 # Data directories (keep structure with .gitkeep)
 data/*
 !data/.gitkeep
+!data/woodpecker/
 data/woodpecker/*
 !data/woodpecker/.gitkeep
+!data/logs/
 data/logs/*
 !data/logs/.gitkeep
+!data/logs/webhook/
+data/logs/webhook/*
+!data/logs/webhook/.gitkeep
 
 # IDE
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12] - 2026-02-08
+
+### Added
+- Webhook handler Docker service (`docker/webhook-handler/Dockerfile`)
+- Traefik `/webhooks` route to webhook-handler container (priority 200, StripPrefix middleware)
+- Webhook deploy pipeline trigger on Dockerfile changes
+- Webhook log persistence directory (`data/logs/webhook/`)
+
+### Changed
+- Traefik priority labels: woodpecker-server `100`, webhook-handler `200`
+- `.env.example`: updated `WEBHOOK_ENDPOINT` default to `https://ci.sparkfn.io/webhooks`, added `WEBHOOK_PORT`, `WOODPECKER_TOKEN`, `WEBHOOK_VERBOSE`
+- `docs/WEBHOOKS.md`: added Docker deployment section, updated payload URLs, updated architecture diagram
+
 ## [0.0.11] - 2026-02-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a CI/CD automation system built on **Woodpecker CI** with AI-powered auto-fix capabilities. It is an infrastructure/DevOps project — there is no application source code, build system, or test suite in this repo. The repo contains pipeline definitions (YAML), shell scripts, configuration files, and templates.
+
+## Common Commands
+
+```bash
+# Start the Woodpecker CI server + agent
+docker compose up -d
+
+# View logs
+docker compose logs -f woodpecker-server
+docker compose logs -f woodpecker-agent
+
+# Stop services
+docker compose down
+
+# Initial setup
+cp .env.example .env          # then edit with real values
+./scripts/setup-github-app.sh  # configure GitHub integration
+```
+
+### Script Usage
+
+```bash
+# AI auto-fix (triggered by failed pipelines)
+./scripts/ai-fix.sh --error-file <path> --repo <path> [--provider claude-code|codex|openhands|opencode]
+
+# Deployment
+./scripts/deploy.sh --env staging --version 1.0.0 --app myapp --config ./config/deploy.yaml
+./scripts/deploy.sh --env production --action status --app myapp
+
+# Create GitHub issue on failure
+./scripts/create-issue.sh --title "Build failed" --template pipeline-failure --repo owner/repo
+
+# Create PR from fix branch
+./scripts/create-pr.sh --source ai-fix/123 --target main --title "Fix: resolve test failure"
+
+# Rollback
+./scripts/rollback.sh --env production --app myapp
+```
+
+All scripts support `--dry-run` and `--verbose` flags.
+
+## Architecture
+
+The system follows this flow: **Watch Repos → Test → Security Scan → Pass/Fail**, then branches:
+
+- **On pass:** Deploy staging → run deployment tests → deploy production (with automatic rollback on health check failure)
+- **On fail:** Create GitHub issue → trigger AI auto-fix → create PR from fix → wait for merge → re-trigger pipeline
+
+### Key Directories
+
+- **`pipelines/`** — Modular Woodpecker pipeline definitions (YAML). `base.yml` provides reusable YAML anchors (`&base_step`, `&main_only`, `&pr_only`, `&tag_only`). Other pipelines import variables/patterns from it.
+- **`scripts/`** — Bash scripts that implement the actual logic invoked by pipeline steps. All use `set -euo pipefail` and follow the same logging pattern (`log_info`, `log_success`, `log_warn`, `log_error`).
+- **`config/`** — YAML configuration files consumed by scripts. `ai-fix.yaml` configures AI providers/strategies, `deploy.yaml` defines per-environment deployment settings, `webhook.yaml` configures event routing, `trivy.yaml` configures security scanning.
+- **`config/issue-templates/`** — Markdown templates for auto-created GitHub issues (test-failure, build-failure, security-vulnerability, pipeline-failure).
+- **`config/pr-templates/`** — Markdown templates for auto-created PRs (default, ai-fix, security-fix, hotfix, feature).
+
+### Pipeline Relationships
+
+1. **`.woodpecker.yml`** — Root pipeline for any repo using this system (validate → install → lint/typecheck → test → build → docker-build → release)
+2. **`pipelines/on-failure.yml`** — Triggered on pipeline failure; creates issues, sends webhooks, archives failure artifacts
+3. **`pipelines/ai-fix.yml`** — Triggered manually or by webhook; runs AI coding agent to fix the failure
+4. **`pipelines/auto-pr.yml`** — Triggered after AI fix; creates a PR from the fix branch
+5. **`pipelines/on-merge.yml`** — Triggered when PR merges to main; runs full tests, builds Docker image, triggers staging deploy
+6. **`pipelines/deploy.yml`** — Staging → production deployment with health checks, rollback, and issue creation on failure
+7. **`pipelines/security.yml`** — Trivy-based scanning (filesystem, dependencies, secrets, IaC, Docker images, SBOM generation)
+
+### AI Auto-fix System
+
+The AI fix loop is configured in `config/ai-fix.yaml` and executed by `scripts/ai-fix.sh`. Supported providers: `claude-code` (priority 1), `codex` (priority 2), `openhands`, `opencode`. The system:
+1. Creates a fix branch from the default branch
+2. Runs the AI provider with error context (up to `max_attempts` times, default 3)
+3. Verifies the fix by running the project's test suite
+4. Commits, pushes, and triggers auto-PR creation
+5. Rolls back on verification failure
+
+Safety limits are defined in `config/ai-fix.yaml` under `safety:` (max 20 files, 500 lines changed; protected files like `.env`, `*.pem`, `*.key`).
+
+### Dual Notification Mechanism
+
+Events are detected via either GitHub webhooks (`scripts/webhook-handler.sh`, configured in `config/webhook.yaml`) or polling (`scripts/poll-service.sh`) for environments where webhooks are unavailable.
+
+## Configuration
+
+All configuration flows through environment variables (`.env` file) and YAML config files. The `.env.example` documents every variable. Key secrets that must be set:
+- `WOODPECKER_AGENT_SECRET` — server-agent auth (generate with `openssl rand -hex 32`)
+- `WOODPECKER_GITHUB_CLIENT` / `WOODPECKER_GITHUB_SECRET` — GitHub OAuth
+- `GITHUB_TOKEN` — for issue/PR creation
+- `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` — for AI auto-fix
+- `WEBHOOK_SECRET` — webhook signature validation
+
+Deployment config (`config/deploy.yaml`) supports multiple methods per environment: `docker`, `docker-compose`, `ssh`, `kubernetes`, `helm`. The deploy script parses this YAML using `yq` (preferred) or `python3` as fallback.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # Woodpecker CI/CD - Docker Compose Configuration
 # =============================================================================
-# Version: 0.0.11
+# Version: 0.0.12
 #
 # This file defines the Woodpecker CI server and agent containers.
 #
@@ -97,6 +97,7 @@ services:
       - "traefik.http.routers.woodpecker.rule=Host(`ci.sparkfn.io`)"
       - "traefik.http.routers.woodpecker.entrypoints=websecure"
       - "traefik.http.routers.woodpecker.tls.certresolver=myresolver"
+      - "traefik.http.routers.woodpecker.priority=100"
       - "traefik.http.services.woodpecker.loadbalancer.server.port=8000"
 
   # ---------------------------------------------------------------------------
@@ -161,6 +162,71 @@ services:
     labels:
       - "com.woodpecker.component=agent"
       - "com.woodpecker.version=v3"
+
+  # ---------------------------------------------------------------------------
+  # Webhook Handler
+  # ---------------------------------------------------------------------------
+  # Receives GitHub/GitLab/Gitea webhook events and routes them to Woodpecker.
+  # Scripts and config are bind-mounted so edits don't require a rebuild.
+  # Traefik routes https://ci.sparkfn.io/webhooks/* to this container.
+  # ---------------------------------------------------------------------------
+  webhook-handler:
+    build:
+      context: .
+      dockerfile: docker/webhook-handler/Dockerfile
+    container_name: webhook-handler
+    restart: unless-stopped
+
+    depends_on:
+      woodpecker-server:
+        condition: service_healthy
+
+    volumes:
+      # Scripts and config (read-only — edit on host, no rebuild needed)
+      - ./scripts:/app/scripts:ro
+      - ./config:/app/config:ro
+      # Logs (writable)
+      - ./data/logs/webhook:/var/log
+
+    environment:
+      - WEBHOOK_PORT=${WEBHOOK_PORT:-9000}
+      - WEBHOOK_SECRET=${WEBHOOK_SECRET}
+      - WOODPECKER_SERVER=http://woodpecker-server:8000
+      - WOODPECKER_TOKEN=${WOODPECKER_TOKEN}
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - WEBHOOK_LOG=/var/log/webhook-handler.log
+      - VERBOSE=${WEBHOOK_VERBOSE:-false}
+
+    networks:
+      - traefik
+
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+        reservations:
+          memory: 32M
+
+    labels:
+      - "com.woodpecker.component=webhook-handler"
+      - "com.woodpecker.version=v3"
+      # Traefik reverse proxy — route /webhooks to this container
+      - "traefik.enable=true"
+      - "traefik.http.routers.webhook-handler.rule=Host(`ci.sparkfn.io`) && PathPrefix(`/webhooks`)"
+      - "traefik.http.routers.webhook-handler.priority=200"
+      - "traefik.http.routers.webhook-handler.entrypoints=websecure"
+      - "traefik.http.routers.webhook-handler.tls.certresolver=myresolver"
+      # Strip /webhooks prefix so the container sees /health, /webhook, etc.
+      - "traefik.http.middlewares.webhook-strip.stripprefix.prefixes=/webhooks"
+      - "traefik.http.routers.webhook-handler.middlewares=webhook-strip"
+      - "traefik.http.services.webhook-handler.loadbalancer.server.port=9000"
 
 # =============================================================================
 # Networks

--- a/docker/webhook-handler/Dockerfile
+++ b/docker/webhook-handler/Dockerfile
@@ -1,0 +1,22 @@
+# =============================================================================
+# Webhook Handler Container
+# =============================================================================
+# Lightweight image for running the webhook-handler.sh script.
+# Scripts and config are bind-mounted at runtime (no COPY needed).
+#
+# Build:   docker compose build webhook-handler
+# Run:     docker compose up -d webhook-handler
+# =============================================================================
+
+FROM python:3.12-alpine
+
+RUN apk add --no-cache bash curl openssl jq
+
+WORKDIR /app
+
+EXPOSE 9000
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=10s \
+  CMD curl -f http://localhost:9000/health || exit 1
+
+ENTRYPOINT ["/app/scripts/webhook-handler.sh", "--serve"]

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -1,6 +1,6 @@
 # Webhook & Polling Guide
 
-> Version: 0.0.10 | Last Updated: 2026-02-07
+> Version: 0.0.12 | Last Updated: 2026-02-08
 
 This guide covers webhook handling and polling services for CI/CD automation with Woodpecker.
 
@@ -36,11 +36,18 @@ Two methods are available for detecting repository events:
           ┌───────────────┴───────────────┐
           │                               │
           ▼                               ▼
-┌─────────────────────┐       ┌─────────────────────┐
-│   Webhook Handler   │       │   Polling Service   │
-│   (webhook-handler) │       │   (poll-service)    │
-│   Port 9000         │       │   Every 60s         │
-└─────────┬───────────┘       └─────────┬───────────┘
+┌─────────────────────────┐   ┌─────────────────────┐
+│   Traefik (HTTPS)       │   │   Polling Service   │
+│   ci.sparkfn.io         │   │   (poll-service)    │
+│   /webhooks → :9000     │   │   Every 60s         │
+└─────────┬───────────────┘   └─────────┬───────────┘
+          │                             │
+          ▼                             │
+┌─────────────────────────┐             │
+│   Webhook Handler       │             │
+│   (Docker container)    │             │
+│   Port 9000             │             │
+└─────────┬───────────────┘             │
           │                             │
           └──────────────┬──────────────┘
                          │
@@ -83,7 +90,7 @@ cat payload.json | ./scripts/webhook-handler.sh --stdin
 1. Go to your repository → Settings → Webhooks → Add webhook
 
 2. Configure:
-   - **Payload URL**: `https://your-server.com:9000/webhook`
+   - **Payload URL**: `https://ci.sparkfn.io/webhooks`
    - **Content type**: `application/json`
    - **Secret**: Your webhook secret
    - **Events**: Select events to trigger on:
@@ -98,7 +105,7 @@ cat payload.json | ./scripts/webhook-handler.sh --stdin
 1. Go to project → Settings → Webhooks
 
 2. Configure:
-   - **URL**: `https://your-server.com:9000/webhook`
+   - **URL**: `https://ci.sparkfn.io/webhooks`
    - **Secret token**: Your webhook secret
    - **Trigger**: Push events, Merge request events, Tag push events
 
@@ -142,6 +149,40 @@ WantedBy=multi-user.target
 sudo systemctl enable webhook-handler
 sudo systemctl start webhook-handler
 ```
+
+### Docker Deployment (Recommended)
+
+The webhook handler runs as a Docker Compose service alongside Woodpecker, with Traefik routing `https://ci.sparkfn.io/webhooks` to the container.
+
+```bash
+# Build and start
+docker compose up -d --build webhook-handler
+
+# View logs
+docker compose logs -f webhook-handler
+
+# Restart after config changes (no rebuild needed — scripts are bind-mounted)
+docker compose restart webhook-handler
+
+# Check health
+curl -f https://ci.sparkfn.io/webhooks/health
+```
+
+**How it works:**
+
+- Traefik listens on `ci.sparkfn.io` and routes `/webhooks/*` to the container on port 9000
+- The `/webhooks` prefix is stripped by a StripPrefix middleware, so the container sees `/health`, `/webhook`, etc.
+- Scripts (`./scripts/`) and config (`./config/`) are bind-mounted read-only — edit on host, restart the container
+- Logs are written to `./data/logs/webhook/` on the host
+
+**Environment variables** are set via `.env` — see `.env.example` for the full list. Key variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `WEBHOOK_PORT` | Container listen port | `9000` |
+| `WEBHOOK_SECRET` | Signature validation secret | — |
+| `WOODPECKER_TOKEN` | Woodpecker API token | — |
+| `WEBHOOK_VERBOSE` | Enable debug logging | `false` |
 
 ---
 
@@ -421,7 +462,7 @@ server {
 3. **Check firewall rules** allow incoming connections on webhook port
 4. **Test with curl**:
    ```bash
-   curl -X POST http://your-server:9000/webhook \
+   curl -X POST https://ci.sparkfn.io/webhooks \
      -H "Content-Type: application/json" \
      -d '{"test": true}'
    ```
@@ -491,7 +532,9 @@ cat /var/lib/poll-service/state.json | python3 -m json.tool
 |------|---------|
 | `scripts/webhook-handler.sh` | Webhook receiver and processor |
 | `scripts/poll-service.sh` | Polling service for change detection |
+| `docker/webhook-handler/Dockerfile` | Container image for webhook handler |
 | `pipelines/on-merge.yml` | Pipeline triggered on PR merge |
+| `pipelines/webhook-listener.yml` | Deploy pipeline for webhook handler |
 | `config/webhook.yaml` | Webhook and polling configuration |
 | `docs/WEBHOOKS.md` | This documentation |
 

--- a/pipelines/webhook-listener.yml
+++ b/pipelines/webhook-listener.yml
@@ -1,0 +1,143 @@
+# =============================================================================
+# Woodpecker CI/CD - Webhook Listener Deploy Pipeline
+# Version: 0.0.12
+#
+# Watches the prod branch for changes to webhook-related files and deploys
+# the webhook-handler service via docker compose on the target server.
+#
+# Trigger: Push to prod branch (auto) or manual
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Pipeline Variables
+# -----------------------------------------------------------------------------
+variables:
+  - &deploy_image "alpine:3.19"
+
+# -----------------------------------------------------------------------------
+# Clone Settings
+# -----------------------------------------------------------------------------
+clone:
+  git:
+    image: woodpeckerci/plugin-git
+    settings:
+      depth: 1
+
+# -----------------------------------------------------------------------------
+# Pipeline Steps
+# -----------------------------------------------------------------------------
+steps:
+  # ---------------------------------------------------------------------------
+  # Stage 1: Validate
+  # ---------------------------------------------------------------------------
+  - name: validate
+    image: *deploy_image
+    commands:
+      - echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - echo "Webhook Listener Deploy Pipeline"
+      - echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - echo "Repository  ${CI_REPO}"
+      - echo "Branch      ${CI_COMMIT_BRANCH}"
+      - echo "Commit      ${CI_COMMIT_SHA:0:8}"
+      - echo "Author      ${CI_COMMIT_AUTHOR}"
+      - echo "Pipeline    #${CI_PIPELINE_NUMBER}"
+      - echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  # ---------------------------------------------------------------------------
+  # Stage 2: Deploy webhook-handler via docker compose
+  # ---------------------------------------------------------------------------
+  - name: deploy-webhook-handler
+    image: *deploy_image
+    commands:
+      - apk add --no-cache openssh-client
+      - mkdir -p ~/.ssh
+      - echo "$SSH_KEY" > ~/.ssh/id_rsa
+      - chmod 600 ~/.ssh/id_rsa
+      - ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+      - |
+        ssh -o StrictHostKeyChecking=no "$DEPLOY_USER@$DEPLOY_HOST" << 'REMOTE'
+          set -euo pipefail
+          cd ${DEPLOY_PATH:-/home/docker/ci-cd-woodpecker}
+          echo "Pulling latest changes..."
+          git pull origin prod
+          echo "Rebuilding and restarting webhook-handler..."
+          docker compose up -d --build --force-recreate webhook-handler
+          echo "Deploy complete."
+        REMOTE
+    secrets:
+      - ssh_key
+      - deploy_host
+      - deploy_user
+      - deploy_path
+    environment:
+      DEPLOY_PATH:
+        from_secret: deploy_path
+
+  # ---------------------------------------------------------------------------
+  # Stage 3: Health check
+  # ---------------------------------------------------------------------------
+  - name: health-check
+    image: *deploy_image
+    commands:
+      - apk add --no-cache curl
+      - |
+        echo "Waiting for webhook-handler to become healthy..."
+        max_attempts=12
+        attempt=0
+        while [ $attempt -lt $max_attempts ]; do
+          if curl -sf "${HEALTH_URL}" > /dev/null 2>&1; then
+            echo "Webhook handler is healthy"
+            exit 0
+          fi
+          attempt=$((attempt + 1))
+          echo "Attempt $attempt/$max_attempts - waiting 5s..."
+          sleep 5
+        done
+        echo "Health check failed after $max_attempts attempts"
+        exit 1
+    environment:
+      HEALTH_URL: ${WEBHOOK_HEALTH_URL:-https://ci.sparkfn.io/webhooks/health}
+
+  # ---------------------------------------------------------------------------
+  # Notifications
+  # ---------------------------------------------------------------------------
+  - name: notify-success
+    image: *deploy_image
+    commands:
+      - echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - echo "Webhook handler deployed successfully"
+      - echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    when:
+      - status: success
+
+  - name: notify-failure
+    image: *deploy_image
+    commands:
+      - echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - echo "Webhook handler deployment FAILED"
+      - echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - echo "Check the logs above for error details."
+    when:
+      - status: failure
+
+# -----------------------------------------------------------------------------
+# Labels
+# -----------------------------------------------------------------------------
+labels:
+  type: deployment
+  service: webhook-handler
+
+# -----------------------------------------------------------------------------
+# When to run this pipeline
+# -----------------------------------------------------------------------------
+when:
+  - event: push
+    branch: prod
+    path:
+      include:
+        - scripts/webhook-handler.sh
+        - config/webhook.yaml
+        - docker-compose.yml
+        - docker/webhook-handler/Dockerfile
+        - pipelines/webhook-listener.yml
+  - event: manual


### PR DESCRIPTION
## Summary
- Add containerized `webhook-handler` service to `docker-compose.yml` with Traefik reverse proxy routing (`https://ci.sparkfn.io/webhooks`)
- Create `docker/webhook-handler/Dockerfile` (python:3.12-alpine with bash, curl, openssl, jq)
- Configure StripPrefix middleware so container sees `/health`, `/webhook` etc. without the `/webhooks` prefix
- Add explicit Traefik priority labels (webhook-handler: `200`, woodpecker-server: `100`) for correct route precedence

## Changes
| File | What |
|------|------|
| `docker/webhook-handler/Dockerfile` | New — container image for webhook handler |
| `docker-compose.yml` | Add service + Traefik labels, bump to v0.0.12 |
| `pipelines/webhook-listener.yml` | Add Dockerfile to path trigger list |
| `.env.example` | Add `WEBHOOK_PORT`, `WOODPECKER_TOKEN`, `WEBHOOK_VERBOSE`; update endpoint URL |
| `.gitignore` | Add `data/logs/webhook/` gitkeep exception |
| `data/logs/webhook/.gitkeep` | New — persist log directory |
| `docs/WEBHOOKS.md` | Docker deployment section, updated URLs and architecture diagram |
| `CHANGELOG.md` | v0.0.12 entry |
| `CLAUDE.md` | Project instructions for Claude Code |

## Test plan
- [ ] `docker compose config` — YAML valid (no errors)
- [ ] `docker compose build webhook-handler` — Dockerfile builds successfully
- [ ] `docker compose up -d webhook-handler` — container starts and becomes healthy
- [ ] `curl -f https://ci.sparkfn.io/webhooks/health` — Traefik routing works
- [ ] Woodpecker UI at `ci.sparkfn.io` still loads (not hijacked by webhook route)
- [ ] After merge, create `prod` branch from updated `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)